### PR TITLE
Improve pr-text regex

### DIFF
--- a/components/pages/Tools/PullRequestsToReleaseText/PullRequestsToReleaseText.tsx
+++ b/components/pages/Tools/PullRequestsToReleaseText/PullRequestsToReleaseText.tsx
@@ -33,8 +33,8 @@ const PullRequestsToReleaseText = (props) => {
   const [excludedContributors, setExcludedContributors] = useState<string[]>(cookie.getValue() || [])
 
   const convert = (rawPullRequestsString) => {
-    const matcher = /(?<title>.*)\n(?<number>#\d+) by (?<contributor>[\w-]+)(?:\sbot)? was (?<action>closed|merged) (?<when>yesterday|(?:.* ago)|(?:on\s\w+\s\d+))/g
-    const grouper = /(?<title>.*)\n(?<number>#\d+) by (?<contributor>[\w-]+)(?:\sbot)? was (?<action>closed|merged) (?<when>yesterday|(?:.* ago)|(?:on\s\w+\s\d+))/
+    const matcher = /(?<title>.+)\n(?<number>#\d+) by (?<contributor>[\w-]+)(?:\sbot)? was (?<action>closed|merged) (?<when>yesterday|(?:.* ago)|(?:on\s\w+\s\d+))/g
+    const grouper = /(?<title>.+)\n(?<number>#\d+) by (?<contributor>[\w-]+)(?:\sbot)? was (?<action>closed|merged) (?<when>yesterday|(?:.* ago)|(?:on\s\w+\s\d+))/
 
     const matches = rawPullRequestsString.match(matcher)
     if (!matches) return setResult('')

--- a/components/pages/Tools/PullRequestsToReleaseText/PullRequestsToReleaseText.tsx
+++ b/components/pages/Tools/PullRequestsToReleaseText/PullRequestsToReleaseText.tsx
@@ -33,8 +33,8 @@ const PullRequestsToReleaseText = (props) => {
   const [excludedContributors, setExcludedContributors] = useState<string[]>(cookie.getValue() || [])
 
   const convert = (rawPullRequestsString) => {
-    const matcher = /(?<title>.+)\n(?<number>#\d+) by (?<contributor>[\w-]+)(?:\sbot)? was (?<action>closed|merged) (?<when>.*) ago/g
-    const grouper = /(?<title>.+)\n(?<number>#\d+) by (?<contributor>[\w-]+)(?:\sbot)? was (?<action>closed|merged) (?<when>.*) ago/
+    const matcher = /(?<title>.*)\n(?<number>#\d+) by (?<contributor>[\w-]+)(?:\sbot)? was (?<action>closed|merged) (?<when>yesterday|(?:.* ago)|(?:on\s\w+\s\d+))/g
+    const grouper = /(?<title>.*)\n(?<number>#\d+) by (?<contributor>[\w-]+)(?:\sbot)? was (?<action>closed|merged) (?<when>yesterday|(?:.* ago)|(?:on\s\w+\s\d+))/
 
     const matches = rawPullRequestsString.match(matcher)
     if (!matches) return setResult('')


### PR DESCRIPTION
Some of the pasted PRs inside the release-text generator were not matched by the regex yet.

This will fix a few cases where that happened.