### PR TITLE
Make contributing to docs easier

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -98,16 +98,16 @@ const config = {
           path: 'notes',
           routeBasePath: '/notes/',
           sidebarPath: require.resolve('./sidebars.js'),
-          // Please change this to your repo.
-          // Remove this to remove the "edit this page" links.
-          editUrl: 'https://github.com/webbertakken/takken.io/tree/main/',
+          editUrl: ({ docPath }) => {
+            return `https://holocron.so/github/pr/webbertakken/takken.io/main/editor/notes/${docPath}`
+          },
         },
         blog: {
           routeBasePath: '/blog/',
           showReadingTime: true,
-          // Please change this to your repo.
-          // Remove this to remove the "edit this page" links.
-          editUrl: 'https://github.com/webbertakken/takken.io/tree/main/',
+          editUrl: ({ docPath }) => {
+            return `https://holocron.so/github/pr/webbertakken/takken.io/main/editor/blog/${docPath}`
+          },
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
With this PR readers can suggest changes to the docs with an easy to use WYSIWYG markdown editor.

[This](https://holocron.so/github/pr/webbertakken/takken.io/main/editor) is how the editor looks like for this repo.

https://github.com/remorses/docusaurus-example/assets/31321188/43c8bc68-3668-4a25-bf1c-a70eceab7bcb