### PR TITLE
chore: re-enable service worker

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -61,30 +61,30 @@ const config: Config = {
         disableInDev: false,
       },
     ],
-    // [
-    //   '@docusaurus/plugin-pwa',
-    //   {
-    //     debug: true,
-    //     offlineModeActivationStrategies: ['appInstalled', 'standalone', 'queryString'],
-    //     pwaHead: [
-    //       {
-    //         tagName: 'link',
-    //         rel: 'icon',
-    //         href: '/images/icons/icon-192x192.png',
-    //       },
-    //       {
-    //         tagName: 'link',
-    //         rel: 'manifest',
-    //         href: '/manifest.json',
-    //       },
-    //       {
-    //         tagName: 'meta',
-    //         name: 'theme-color',
-    //         content: 'rgb(255, 54, 136)',
-    //       },
-    //     ],
-    //   },
-    // ],
+    [
+      '@docusaurus/plugin-pwa',
+      {
+        debug: true,
+        offlineModeActivationStrategies: ['appInstalled', 'standalone', 'queryString'],
+        pwaHead: [
+          {
+            tagName: 'link',
+            rel: 'icon',
+            href: '/images/icons/icon-192x192.png',
+          },
+          {
+            tagName: 'link',
+            rel: 'manifest',
+            href: '/manifest.json',
+          },
+          {
+            tagName: 'meta',
+            name: 'theme-color',
+            content: 'rgb(255, 54, 136)',
+          },
+        ],
+      },
+    ],
   ],
   presets: [
     [


### PR DESCRIPTION
#### Changes

- The serviceworker broke during the upgrade process to Docusaurus v3, however one of the last commits fixing a few types must have fixed it somehow because it seems to work again.

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the
  [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme (updated or not needed)
- [x] Tests (added, updated or not needed)
