### PR TITLE
blog: update descriptions to reflect two-part split

### DIFF
--- a/blog/2026-04-23-the-making-of-a-model-in-simple-words/index.mdx
+++ b/blog/2026-04-23-the-making-of-a-model-in-simple-words/index.mdx
@@ -1,10 +1,10 @@
 ---
 slug: the-making-of-a-model-in-simple-words
 title: The making of a model, in simple words
-description:
+description: >-
   Part 1 of a plain-language tour of how coding agents work: how a large language model is made,
-  from scraping the internet to tokenisation, pre-training, post-training and inference on
-  provider infrastructure.
+  from scraping the internet to tokenisation, pre-training, post-training and inference on provider
+  infrastructure.
 authors: [webber]
 tags:
   - Agents

--- a/blog/2026-04-23-the-making-of-a-model-in-simple-words/index.mdx
+++ b/blog/2026-04-23-the-making-of-a-model-in-simple-words/index.mdx
@@ -2,8 +2,9 @@
 slug: the-making-of-a-model-in-simple-words
 title: The making of a model, in simple words
 description:
-  A plain-language tour of how coding agents work, from training data on the provider side to tool
-  calls and AGENTS.md on the client side.
+  Part 1 of a plain-language tour of how coding agents work: how a large language model is made,
+  from scraping the internet to tokenisation, pre-training, post-training and inference on
+  provider infrastructure.
 authors: [webber]
 tags:
   - Agents

--- a/blog/2026-04-24-the-anatomy-of-a-coding-agent/index.mdx
+++ b/blog/2026-04-24-the-anatomy-of-a-coding-agent/index.mdx
@@ -1,9 +1,9 @@
 ---
 slug: the-anatomy-of-a-coding-agent
 title: The anatomy of a coding agent
-description:
-  Part 2 of a plain-language tour of how coding agents work: what happens on your own machine,
-  from the harness and its request anatomy to tools, AGENTS.md and progressive disclosure.
+description: >-
+  Part 2 of a plain-language tour of how coding agents work: what happens on your own machine, from
+  the harness and its request anatomy to tools, AGENTS.md and progressive disclosure.
 authors: [webber]
 tags:
   - Agents

--- a/blog/2026-04-24-the-anatomy-of-a-coding-agent/index.mdx
+++ b/blog/2026-04-24-the-anatomy-of-a-coding-agent/index.mdx
@@ -2,8 +2,8 @@
 slug: the-anatomy-of-a-coding-agent
 title: The anatomy of a coding agent
 description:
-  A plain-language tour of how coding agents work, from training data on the provider side to tool
-  calls and AGENTS.md on the client side.
+  Part 2 of a plain-language tour of how coding agents work: what happens on your own machine,
+  from the harness and its request anatomy to tools, AGENTS.md and progressive disclosure.
 authors: [webber]
 tags:
   - Agents


### PR DESCRIPTION
Each post now describes only its own scope:

- **Part 1** (`the-making-of-a-model-in-simple-words`) focuses on how a model is made on the provider side.
- **Part 2** (`the-anatomy-of-a-coding-agent`, still `draft: true`) focuses on the client side: harness, request anatomy, tools, AGENTS.md and progressive disclosure.

No body content changes - only frontmatter descriptions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated blog post descriptions to reframe articles as a two-part series on language models and agents.
  * Part 1 now emphasises the foundational process of creating language models, covering data sourcing through training and inference stages.
  * Part 2 details the anatomy of coding agents operating on your machine, including request structure and tool interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->