### PR TITLE
fix: refresh giscus widget on blog route change

### DIFF
--- a/src/components/common/CommentsSection.tsx
+++ b/src/components/common/CommentsSection.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import Giscus from '@giscus/react'
 import { useColorMode } from '@docusaurus/theme-common'
+import { useLocation } from '@docusaurus/router'
 
 interface Props {
   category: string
@@ -9,6 +10,7 @@ interface Props {
 
 const CommentsSection = ({ category, categoryId }: Props): JSX.Element => {
   const { colorMode: theme } = useColorMode()
+  const { pathname } = useLocation()
 
   return (
     <div role="region" aria-label="Comments section">
@@ -22,7 +24,15 @@ const CommentsSection = ({ category, categoryId }: Props): JSX.Element => {
         />
       </h2>
 
+      {/*
+       * The `key` forces a fresh `<giscus-widget>` (and its iframe) to mount on
+       * every route change. Without it, Docusaurus' SPA navigation reuses the
+       * same widget instance and — because all props below are static — the
+       * giscus lit element never triggers `updateConfig`, leaving the previous
+       * post's discussion visible.
+       */}
       <Giscus
+        key={pathname}
         id="comments"
         repo="webbertakken/takken.io"
         repoId="MDEwOlJlcG9zaXRvcnkzNDk3MTQyOTA="


### PR DESCRIPTION
## Problem

When navigating between blog posts (and notes), the giscus comments widget kept showing the previous page's discussion instead of updating to match the new route.

## Cause

The giscus lit element (`node_modules/giscus/dist/giscus.mjs`) only re-syncs its iframe when one of its attributes changes \u2014 `requestUpdate` \u2192 `updateConfig`. All props passed to `<Giscus>` in `CommentsSection.tsx` were static across blog posts (`category`, `categoryId`, `mapping="title"`, `term="Comments"`, \u2026), so during Docusaurus' SPA navigation the same `<giscus-widget>` instance was reused and never told to reload.

`@giscus/react` (3.1.0) and `giscus` (1.6.0) are both already on the latest releases, so this is structural rather than a missing upstream fix.

## Fix

Force a fresh `<giscus-widget>` mount on every route change by keying the React element on the current pathname via `useLocation` from `@docusaurus/router`. The new widget instance reads the now-updated `document.title` and renders the right discussion.

## Verification

- `yarn lint` clean
- `yarn typecheck` clean
- `vitest related` \u2014 no related tests
- prettier \u2014 already formatted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the comments section to properly refresh when navigating between pages, preventing outdated discussions from appearing on different pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->