### PR TITLE
chore: switch typechecking to tsgo

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lint:css": "stylelint **/*.{css,scss,sass} --fix",
     "format": "prettier --write .",
     "fix": "yarn format && yarn lint:css && yarn lint --fix",
-    "typecheck": "tsc --skipLibCheck --noEmit",
+    "typecheck": "tsgo --skipLibCheck --noEmit",
     "prepare": "husky install",
     "image": "ts-node tools/image-generator/index.ts"
   },
@@ -30,7 +30,7 @@
       "shellcheck",
       "git update-index --chmod=+x"
     ],
-    "*.@(ts|tsx|mts)": "bash -c 'tsc --skipLibCheck --noEmit'",
+    "*.@(ts|tsx|mts)": "bash -c 'tsgo --skipLibCheck --noEmit'",
     "*.@(ts|tsx|mts|js|jsx|mjs|cjs)": [
       "eslint --max-warnings 0",
       "vitest related --run"
@@ -77,7 +77,6 @@
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^3.9.2",
-    "@docusaurus/tsconfig": "^3.9.2",
     "@docusaurus/types": "^3.9.2",
     "@tailwindcss/webpack": "^4.2.0",
     "@testing-library/dom": "^10.4.0",
@@ -91,6 +90,7 @@
     "@types/react": "^18.3.1",
     "@typescript-eslint/eslint-plugin": "^8.37.0",
     "@typescript-eslint/parser": "^8.37.0",
+    "@typescript/native-preview": "7.0.0-dev.20260425.1",
     "@vitest/coverage-v8": "^3.2.4",
     "cross-env": "^7.0.3",
     "dotenv": "^17.2.0",

--- a/src/domain/diving/garmin/GarminFiles.ts
+++ b/src/domain/diving/garmin/GarminFiles.ts
@@ -55,7 +55,10 @@ export class GarminFiles {
     })
 
     return Object.entries(decompressedFiles).map(
-      ([filename, bytes]) => new File([bytes] as Uint8Array[], filename),
+      // fflate's `unzipSync` always allocates a regular ArrayBuffer (never
+      // SharedArrayBuffer), so narrowing the buffer type is safe and required
+      // by the stricter DOM `BlobPart` typings.
+      ([filename, bytes]) => new File([bytes as Uint8Array<ArrayBuffer>], filename),
     )
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,23 @@
 {
   // This file is not used in compilation. It is here just for a nice editor experience.
-  "extends": "@docusaurus/tsconfig",
+  // We previously extended `@docusaurus/tsconfig` but it sets `baseUrl`, which
+  // tsgo (TypeScript 7 native preview) has removed. Settings are inlined here
+  // so we control them directly.
   "compilerOptions": {
-    "strict": true,
-    "baseUrl": ".",
+    "allowJs": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
     "jsx": "react-jsx",
-    "target": "ES2020",
+    "lib": ["ES2022", "DOM"],
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "allowSyntheticDefaultImports": true
+    "noEmit": true,
+    "paths": {
+      "@site/*": ["./*"]
+    },
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2020"
   },
   "exclude": ["node_modules", "cypress", "dist", "build", ".yarn", "functions"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4551,13 +4551,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@docusaurus/tsconfig@npm:^3.9.2":
-  version: 3.9.2
-  resolution: "@docusaurus/tsconfig@npm:3.9.2"
-  checksum: 10/8e08e352ab8285d4601822dbd424700a7c875b30dd2eefb087f540e62e5a9f05026368625ce3e89948380f0b232ecd7a52e03ce069fab4de1e6a39dedf324d1b
-  languageName: node
-  linkType: hard
-
 "@docusaurus/types@npm:3.1.1, @docusaurus/types@npm:^3.1.1":
   version: 3.1.1
   resolution: "@docusaurus/types@npm:3.1.1"
@@ -9366,6 +9359,87 @@ __metadata:
     "@typescript-eslint/types": "npm:8.37.0"
     eslint-visitor-keys: "npm:^4.2.1"
   checksum: 10/f56a82289659af3852207c4b1107c84d9008ff3586a8896c02015e07f1ec97243bc1a73e629e0829cb93060ea2fe03c18ea5b343a4e7cbe6679587233117a2db
+  languageName: node
+  linkType: hard
+
+"@typescript/native-preview-darwin-arm64@npm:7.0.0-dev.20260425.1":
+  version: 7.0.0-dev.20260425.1
+  resolution: "@typescript/native-preview-darwin-arm64@npm:7.0.0-dev.20260425.1"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@typescript/native-preview-darwin-x64@npm:7.0.0-dev.20260425.1":
+  version: 7.0.0-dev.20260425.1
+  resolution: "@typescript/native-preview-darwin-x64@npm:7.0.0-dev.20260425.1"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@typescript/native-preview-linux-arm64@npm:7.0.0-dev.20260425.1":
+  version: 7.0.0-dev.20260425.1
+  resolution: "@typescript/native-preview-linux-arm64@npm:7.0.0-dev.20260425.1"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@typescript/native-preview-linux-arm@npm:7.0.0-dev.20260425.1":
+  version: 7.0.0-dev.20260425.1
+  resolution: "@typescript/native-preview-linux-arm@npm:7.0.0-dev.20260425.1"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@typescript/native-preview-linux-x64@npm:7.0.0-dev.20260425.1":
+  version: 7.0.0-dev.20260425.1
+  resolution: "@typescript/native-preview-linux-x64@npm:7.0.0-dev.20260425.1"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@typescript/native-preview-win32-arm64@npm:7.0.0-dev.20260425.1":
+  version: 7.0.0-dev.20260425.1
+  resolution: "@typescript/native-preview-win32-arm64@npm:7.0.0-dev.20260425.1"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@typescript/native-preview-win32-x64@npm:7.0.0-dev.20260425.1":
+  version: 7.0.0-dev.20260425.1
+  resolution: "@typescript/native-preview-win32-x64@npm:7.0.0-dev.20260425.1"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@typescript/native-preview@npm:7.0.0-dev.20260425.1":
+  version: 7.0.0-dev.20260425.1
+  resolution: "@typescript/native-preview@npm:7.0.0-dev.20260425.1"
+  dependencies:
+    "@typescript/native-preview-darwin-arm64": "npm:7.0.0-dev.20260425.1"
+    "@typescript/native-preview-darwin-x64": "npm:7.0.0-dev.20260425.1"
+    "@typescript/native-preview-linux-arm": "npm:7.0.0-dev.20260425.1"
+    "@typescript/native-preview-linux-arm64": "npm:7.0.0-dev.20260425.1"
+    "@typescript/native-preview-linux-x64": "npm:7.0.0-dev.20260425.1"
+    "@typescript/native-preview-win32-arm64": "npm:7.0.0-dev.20260425.1"
+    "@typescript/native-preview-win32-x64": "npm:7.0.0-dev.20260425.1"
+  dependenciesMeta:
+    "@typescript/native-preview-darwin-arm64":
+      optional: true
+    "@typescript/native-preview-darwin-x64":
+      optional: true
+    "@typescript/native-preview-linux-arm":
+      optional: true
+    "@typescript/native-preview-linux-arm64":
+      optional: true
+    "@typescript/native-preview-linux-x64":
+      optional: true
+    "@typescript/native-preview-win32-arm64":
+      optional: true
+    "@typescript/native-preview-win32-x64":
+      optional: true
+  bin:
+    tsgo: bin/tsgo.js
+  checksum: 10/1e26dd9a6f8e899a7b0397a72376512cc29e49995e5d12e6084877796b36652b665c0032bfd3890722a9ba275435137f555087d63e07ed6ea72f14f3299c0e31
   languageName: node
   linkType: hard
 
@@ -23909,7 +23983,6 @@ __metadata:
     "@docusaurus/plugin-pwa": "npm:^3.9.2"
     "@docusaurus/preset-classic": "npm:^3.9.2"
     "@docusaurus/theme-mermaid": "npm:^3.9.2"
-    "@docusaurus/tsconfig": "npm:^3.9.2"
     "@docusaurus/types": "npm:^3.9.2"
     "@docusaurus/utils-validation": "npm:^3.9.2"
     "@garmin-fit/sdk": "npm:^21.115.0"
@@ -23930,6 +24003,7 @@ __metadata:
     "@types/react-dom": "npm:^18.3.1"
     "@typescript-eslint/eslint-plugin": "npm:^8.37.0"
     "@typescript-eslint/parser": "npm:^8.37.0"
+    "@typescript/native-preview": "npm:7.0.0-dev.20260425.1"
     "@vitest/coverage-v8": "npm:^3.2.4"
     canvas: "npm:^3.1.2"
     clsx: "npm:^2.1.1"


### PR DESCRIPTION
## What

Move all type-checking from `tsc` to **tsgo** (`@typescript/native-preview`), the Go port of the TypeScript compiler.

- `yarn typecheck` now runs `tsgo --skipLibCheck --noEmit`.
- The lint-staged hook for `.ts`/`.tsx`/`.mts` runs `tsgo --skipLibCheck --noEmit`.
- CI already invokes `yarn typecheck` (in `main.yaml` and `pull-request.yaml`), so it picks this up with no workflow changes.
- No `tsc` fallback anywhere in the type-checking pipeline. The `functions/` workspace still uses `tsc` because it relies on emit (Firebase deploy), which tsgo's emit pipeline isn't ready for yet.

## Why

Faster local checks and pre-commit hooks. Local benchmark on this repo:

| | wall | user |
| --- | --- | --- |
| `tsc --skipLibCheck --noEmit` | 1.94s | 3.69s |
| `tsgo --skipLibCheck --noEmit` | 0.66s | 2.66s |

\u2248 3\u00d7 wall-time speedup even on a small codebase. The win compounds in the lint-staged hook that runs on every commit.

## Notable changes

### `tsconfig.json` no longer extends `@docusaurus/tsconfig`

tsgo (TypeScript 7 native preview) removed `baseUrl`, but `@docusaurus/tsconfig` still sets it. Since extended configs can't "unset" a value, the upstream settings are inlined here (with `baseUrl` dropped and `paths` carrying the `@site/*` alias instead). `@docusaurus/tsconfig` is removed from `devDependencies`.

### Real type bug surfaced in `GarminFiles.ts`

The stricter DOM `BlobPart` typings (reachable via the updated lib) caught a hidden mismatch:

```ts
- new File([bytes] as Uint8Array[], filename)
+ new File([bytes as Uint8Array<ArrayBuffer>], filename)
```

The previous cast hid that fflate's `Uint8Array<ArrayBufferLike>` isn't assignable to `BlobPart` (which forbids `SharedArrayBuffer`-backed buffers). fflate's `unzipSync` never allocates `SharedArrayBuffer`, so narrowing the cast is correct.

### Pinned dev release

`@typescript/native-preview` is pinned to `7.0.0-dev.20260425.1` (no `^`) because it is daily-tagged dev software \u2014 we want deliberate bumps, not float.

### `typescript` itself stays

Still required by `@typescript-eslint` for type-aware lint rules and by the editor language service. Not a `tsc` backstop \u2014 nothing in our scripts invokes it.

## Verification

- `yarn typecheck` clean (with tsgo)
- `yarn lint` clean
- `yarn test --run` \u2014 163/163 unit tests pass
- `yarn build` \u2014 full Docusaurus build succeeds; post-build security tests pass
- prettier \u2014 already formatted

## Caveats

- tsgo is a dev-tagged preview. Some less-common compiler features aren't fully implemented yet, but for `--noEmit` checking on this codebase everything works.
- The editor language service (VS Code, WebStorm) still uses regular `tsc` \u2014 unchanged.
- A handful of CodeQL/dependabot warnings exist on `main` already (82 vulnerabilities flagged on push); unrelated to this PR.