### PR TITLE
feat: respect OS colour scheme preference on first load

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -203,6 +203,10 @@ export default {
   ],
 
   themeConfig: {
+    colorMode: {
+      defaultMode: 'light',
+      respectPrefersColorScheme: true,
+    },
     metadata: [
       {
         name: 'darkreader-lock',


### PR DESCRIPTION
## Problem

The site always opened in light mode, even for visitors whose OS is set to dark mode.

## Cause

`docusaurus.config.ts` did not configure `themeConfig.colorMode`, so Docusaurus used its built-in defaults:

```ts
{
  defaultMode: 'light',
  disableSwitch: false,
  respectPrefersColorScheme: false, // <-- this is why
}
```

With `respectPrefersColorScheme: false`, the system `prefers-color-scheme` media query is ignored on first visit.

## Fix

Add an explicit `colorMode` block with `respectPrefersColorScheme: true`. Behaviour:

- **First visit** \u2014 follow the OS preference (dark or light).
- **After manual toggle** \u2014 Docusaurus persists the choice to localStorage and stops following the system setting (standard Docusaurus behaviour, no extra code needed).

`defaultMode: 'light'` is kept for the rare case where the browser reports no preference.

## Verification

- `yarn typecheck` clean (tsgo)
- `yarn lint` clean
- `yarn build` \u2014 full Docusaurus build green; post-build security tests 3/3 pass
- prettier \u2014 already formatted

The Vercel preview can be used to confirm by toggling OS dark/light and reloading in a private window (so localStorage starts empty).