### PR TITLE
feat: only show profile icon on /learning

### DIFF
--- a/src/theme/Navbar/Content/index.tsx
+++ b/src/theme/Navbar/Content/index.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import OriginalNavbarContent from '@theme-original/Navbar/Content'
+import { useLocation } from '@docusaurus/router'
 import clsx from 'clsx'
 import { useAuth } from '@site/src/contexts/AuthContext'
 
@@ -117,6 +118,13 @@ const ProfileMenu = (): React.ReactElement => {
 }
 
 const NavbarContent = (): React.ReactElement => {
+  const { pathname } = useLocation()
+  const isLearningPage = pathname === '/learning' || pathname.startsWith('/learning/')
+
+  if (!isLearningPage) {
+    return <OriginalNavbarContent />
+  }
+
   return (
     <div className="flex w-full items-center">
       <div className="flex-1">


### PR DESCRIPTION
## Problem

The profile icon (signed-in avatar / initials / anonymous user icon) was visible in the navbar on every page. On all routes except `/learning` it has no purpose, which is confusing for visitors.

## Cause

`src/theme/Navbar/Content/index.tsx` swizzles the navbar and always appends `<ProfileMenu />`, regardless of route.

## Fix

Gate `<ProfileMenu />` on the current pathname using `useLocation` from `@docusaurus/router`. On non-`/learning` routes return the unmodified `OriginalNavbarContent`; on `/learning` (and any future sub-routes) keep the wrapper that hosts the menu.

```tsx
const { pathname } = useLocation()
const isLearningPage = pathname === '/learning' || pathname.startsWith('/learning/')

if (!isLearningPage) {
  return <OriginalNavbarContent />
}
// \u2026 wrapper + ProfileMenu \u2026
```

## Verification

Server-rendered HTML count of the profile menu (`aria-label="User menu"`):

| Page | Before | After |
| --- | --- | --- |
| `/` | 1 | **0** |
| `/blog/the-making-of-a-model-in-simple-words` | 1 | **0** |
| `/learning` | 1 | **1** |

- `yarn typecheck` clean (tsgo)
- `yarn lint` clean
- `yarn build` \u2014 full Docusaurus build green; post-build security tests 3/3 pass
- prettier \u2014 already formatted