### PR TITLE
chore: upgrade husky 8 to 9

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,8 +1,4 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 # If tty is available, apply fix from https://github.com/typicode/husky/issues/968#issuecomment-1176848345
 if sh -c ": >/dev/tty" >/dev/null 2>/dev/null; then exec >/dev/tty 2>&1; fi
 
-# Heavy checks should only be done on staged files123
 yarn lint-staged

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "format": "prettier --write .",
     "fix": "yarn format && yarn lint:css && yarn lint --fix",
     "typecheck": "tsgo --skipLibCheck --noEmit",
-    "prepare": "husky install",
+    "prepare": "husky",
     "image": "ts-node tools/image-generator/index.ts"
   },
   "lint-staged": {
@@ -93,7 +93,7 @@
     "cross-env": "^10",
     "dotenv": "^17.4.2",
     "glob": "^13.0.6",
-    "husky": "8.0.3",
+    "husky": "^9",
     "jsdom": "^29",
     "lint-staged": "^16",
     "oxlint": "^1.61.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15658,12 +15658,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"husky@npm:8.0.3":
-  version: 8.0.3
-  resolution: "husky@npm:8.0.3"
+"husky@npm:^9":
+  version: 9.1.7
+  resolution: "husky@npm:9.1.7"
   bin:
-    husky: lib/bin.js
-  checksum: 10/b754cf70fdc97c3b60fec5b80056b9c11436464953b1691bf2b5dcf0081fb6685d2c5f47abb8b2b1c49f504aabea5321fdd6496f8b755d9f6e7525a493406abb
+    husky: bin.js
+  checksum: 10/c2412753f15695db369634ba70f50f5c0b7e5cb13b673d0826c411ec1bd9ddef08c1dad89ea154f57da2521d2605bd64308af748749b27d08c5f563bcd89975f
   languageName: node
   linkType: hard
 
@@ -24125,7 +24125,7 @@ __metadata:
     fflate: "npm:^0.8.2"
     firebase: "npm:^12.12.1"
     glob: "npm:^13.0.6"
-    husky: "npm:8.0.3"
+    husky: "npm:^9"
     js-cookie: "npm:^3.0.5"
     jsdom: "npm:^29"
     lint-staged: "npm:^16"


### PR DESCRIPTION
## What

Husky 8 \u2192 9 migration.

## Changes

- `package.json`: `prepare` script `husky install` \u2192 `husky`.
- `.husky/pre-commit`: drop the `. "$(dirname -- "$0")/_/husky.sh"` source line. Husky 9 hooks are plain shell scripts.

## Verification

- `yarn prepare` recreates `.husky/_/` correctly.
- The pre-commit hook actually fired during the commit for this PR \u2014 lint-staged ran and prettified `package.json` as expected.
- `yarn lint`, `yarn typecheck`, `yarn test --run` (163/163), `yarn build` all pass.