### PR TITLE
chore: upgrade React 18 to 19

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@mdx-js/react": "^3.1.1",
     "@react-spring/web": "^10.0.3",
     "@types/dedent": "^0.7.2",
-    "@types/react-dom": "^18.3.7",
+    "@types/react-dom": "^19",
     "canvas": "^3.2.3",
     "clsx": "^2.1.1",
     "docusaurus-gtm-plugin": "^0.0.2",
@@ -64,8 +64,8 @@
     "node-fetch": "2",
     "prism-react-renderer": "^2.4.1",
     "qrcode.react": "^4.2.0",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
+    "react": "^19",
+    "react-dom": "^19",
     "react-hot-toast": "^2.6.0",
     "react-icons": "^5.6.0",
     "react-simple-code-editor": "^0.14.1",
@@ -87,7 +87,7 @@
     "@types/jest": "^30.0.0",
     "@types/js-cookie": "^3.0.6",
     "@types/node": "^25",
-    "@types/react": "^18.3.28",
+    "@types/react": "^19",
     "@typescript/native-preview": "7.0.0-dev.20260425.1",
     "@vitest/coverage-v8": "^4",
     "cross-env": "^10",
@@ -110,7 +110,9 @@
     "yarn-upgrade-all": "^0.8.1"
   },
   "resolutions": {
-    "sharp": "^0.34.4"
+    "sharp": "^0.34.4",
+    "@types/react": "^19",
+    "@types/react-dom": "^19"
   },
   "browserslist": {
     "production": [

--- a/src/components/ImageWrapper.tsx
+++ b/src/components/ImageWrapper.tsx
@@ -1,6 +1,6 @@
 import React, { PropsWithChildren } from 'react'
 
-const ImageWrapper = ({ children }: PropsWithChildren<object>): JSX.Element => {
+const ImageWrapper = ({ children }: PropsWithChildren<object>): React.JSX.Element => {
   return <div style={{ display: 'flex', gap: '2rem', paddingBottom: '1rem' }}>{children}</div>
 }
 

--- a/src/components/common/CommentsSection.tsx
+++ b/src/components/common/CommentsSection.tsx
@@ -8,7 +8,7 @@ interface Props {
   categoryId: string
 }
 
-const CommentsSection = ({ category, categoryId }: Props): JSX.Element => {
+const CommentsSection = ({ category, categoryId }: Props): React.JSX.Element => {
   const { colorMode: theme } = useColorMode()
   const { pathname } = useLocation()
 

--- a/src/components/tools/GarminToSsiDiveLogHelper/index.tsx
+++ b/src/components/tools/GarminToSsiDiveLogHelper/index.tsx
@@ -19,7 +19,7 @@ const interestingMessages = [
   'tankSummaryMesgs',
 ]
 
-const GarminToSsiDiveLogHelper = (): JSX.Element => {
+const GarminToSsiDiveLogHelper = (): React.JSX.Element => {
   const fileInputRef = createRef<HTMLInputElement>()
   const [messages, setMessages] = useState<GarminMessages | null>(null)
   const [ssiDive, setSsiDive] = useState<Partial<SsiDive> | null>(null)

--- a/src/components/tools/TasmotaHelper/calibrateWithEnergyMeter.tsx
+++ b/src/components/tools/TasmotaHelper/calibrateWithEnergyMeter.tsx
@@ -5,7 +5,7 @@ import { dedent } from 'ts-dedent'
 import React, { useEffect, useState } from 'react'
 import { toolStyles } from '../toolStyles'
 
-const CalibrateWithEnergyMeter = (): JSX.Element => {
+const CalibrateWithEnergyMeter = (): React.JSX.Element => {
   const [power, setPower] = useState<string>('63')
   const [voltage, setVoltage] = useState<string>('234.5')
   const [current, setCurrent] = useState<string>('0')

--- a/src/components/tools/TasmotaHelper/calibrateWithMultiMeter.tsx
+++ b/src/components/tools/TasmotaHelper/calibrateWithMultiMeter.tsx
@@ -5,7 +5,7 @@ import CodeBlock from '@site/src/components/common/CodeBlock'
 import { dedent } from 'ts-dedent'
 import React, { useEffect, useState } from 'react'
 
-const CalibrateWithMultiMeter = (): JSX.Element => {
+const CalibrateWithMultiMeter = (): React.JSX.Element => {
   const [wattage, setWattage] = useState<string>('0')
   const [voltage, setVoltage] = useState<string>('234.5')
   const [amperage, setAmperage] = useState<string>('0.27')

--- a/src/components/tools/TasmotaHelper/index.tsx
+++ b/src/components/tools/TasmotaHelper/index.tsx
@@ -3,7 +3,7 @@ import ToolPage from '@theme/ToolPage/ToolPage'
 import CalibrateWithEnergyMeter from './calibrateWithEnergyMeter'
 import CalibrateWithMultiMeter from './calibrateWithMultiMeter'
 
-const TasmotaHelper = (): JSX.Element => {
+const TasmotaHelper = (): React.JSX.Element => {
   return (
     <ToolPage title="Tasmota helper">
       <CalibrateWithEnergyMeter />

--- a/src/components/tools/TextAnalyser/index.tsx
+++ b/src/components/tools/TextAnalyser/index.tsx
@@ -15,7 +15,7 @@ but lick left leg for ninety minutes, still dirty spot something, big eyes, crou
 
 prepare to pounce for lick the other cats. Bite plants cough fur ball for ears back wide eyed whoops`
 
-const TextAnalyser = (): JSX.Element => {
+const TextAnalyser = (): React.JSX.Element => {
   // Basics
   const [lineCount, setLineCount] = useState<number>(0)
   const [characterCount, setCharacterCount] = useState<number>(0)

--- a/src/pages/tools/index.tsx
+++ b/src/pages/tools/index.tsx
@@ -8,7 +8,7 @@ const tools = [
   { name: 'Comma separator', slug: 'comma-separator' },
 ]
 
-const Tools = (): JSX.Element => {
+const Tools = (): React.JSX.Element => {
   return (
     <ToolPageLayout title="Tools">
       <ul>

--- a/src/theme/BlogPostItem/Header/Title/index.tsx
+++ b/src/theme/BlogPostItem/Header/Title/index.tsx
@@ -4,7 +4,7 @@ import Link from '@docusaurus/Link'
 import { useBlogPost } from '@docusaurus/plugin-content-blog/client'
 import type { Props } from '@theme/BlogPostItem/Header/Title'
 
-export default function BlogPostItemHeaderTitle({ className }: Props): JSX.Element {
+export default function BlogPostItemHeaderTitle({ className }: Props): React.JSX.Element {
   const { metadata, isBlogPostPage } = useBlogPost()
   const { permalink, title } = metadata
   const TitleHeading = isBlogPostPage ? 'h1' : 'h2'

--- a/src/theme/BlogPostItem/index.tsx
+++ b/src/theme/BlogPostItem/index.tsx
@@ -7,7 +7,7 @@ import CommentsSection from '@site/src/components/common/CommentsSection'
 
 type Props = WrapperProps<typeof BlogPostItemType>
 
-export default function BlogPostItemWrapper(props: Props): JSX.Element {
+export default function BlogPostItemWrapper(props: Props): React.JSX.Element {
   const { isBlogPostPage } = useBlogPost()
 
   return (

--- a/src/theme/DocItem/Content/index.tsx
+++ b/src/theme/DocItem/Content/index.tsx
@@ -6,7 +6,7 @@ import CommentsSection from '@site/src/components/common/CommentsSection'
 
 type Props = WrapperProps<typeof ContentType>
 
-export default function ContentWrapper(props: Props): JSX.Element {
+export default function ContentWrapper(props: Props): React.JSX.Element {
   return (
     <>
       <Content {...props} />

--- a/src/theme/DocPage/Layout/Main/index.tsx
+++ b/src/theme/DocPage/Layout/Main/index.tsx
@@ -5,7 +5,7 @@ import type { WrapperProps } from '@docusaurus/types'
 
 type Props = WrapperProps<typeof MainType>
 
-export default function MainWrapper(props: Props): JSX.Element {
+export default function MainWrapper(props: Props): React.JSX.Element {
   return (
     <>
       <div id="docContainerPadding" />

--- a/src/theme/Image/index.tsx
+++ b/src/theme/Image/index.tsx
@@ -6,7 +6,7 @@ interface Props {
   year?: number
 }
 
-const Image = ({ src, alt, year, ...props }: Props): JSX.Element => {
+const Image = ({ src, alt, year, ...props }: Props): React.JSX.Element => {
   return (
     <div className="flex flex-col items-center py-4">
       <img className="max-h-96 lg:max-h-[32rem] xl:max-h-[40rem]" {...props} src={src} alt={alt} />

--- a/src/theme/Logo/index.tsx
+++ b/src/theme/Logo/index.tsx
@@ -9,7 +9,7 @@ interface Props extends WrapperProps<typeof LogoType> {
   titleClassName?: string
 }
 
-export default function LogoWrapper(props: Props): JSX.Element {
+export default function LogoWrapper(props: Props): React.JSX.Element {
   const location = useLocation()
 
   const titleClassName = clsx(props.titleClassName, {

--- a/src/theme/MDXComponents/Heading.tsx
+++ b/src/theme/MDXComponents/Heading.tsx
@@ -6,7 +6,7 @@ import { useLocation } from '@docusaurus/router'
 
 type Props = WrapperProps<typeof HeadingType>
 
-export default function HeadingWrapper(props: Props): JSX.Element {
+export default function HeadingWrapper(props: Props): React.JSX.Element {
   const location = useLocation()
   const isBlogPost = location.pathname.startsWith('/blog/')
 

--- a/src/theme/PoemAudio/index.tsx
+++ b/src/theme/PoemAudio/index.tsx
@@ -8,7 +8,7 @@ interface Props {
   isSong?: boolean
 }
 
-const PoemAudio = (props: Props): JSX.Element => {
+const PoemAudio = (props: Props): React.JSX.Element => {
   const { performer, isSong, ...audioProps } = props
   return (
     <div className="flex flex-col items-center py-8 px-4">

--- a/src/theme/PoemText/index.tsx
+++ b/src/theme/PoemText/index.tsx
@@ -4,7 +4,7 @@ interface Props {
   children: string
 }
 
-const PoemText = ({ children }: Props): JSX.Element => {
+const PoemText = ({ children }: Props): React.JSX.Element => {
   return (
     <div>
       <div className="text-2xl whitespace-pre [&_p]:leading-5 [&_p]:py-3">{children}</div>

--- a/src/theme/ToolPage/ToolPage.tsx
+++ b/src/theme/ToolPage/ToolPage.tsx
@@ -6,7 +6,7 @@ interface Props {
   children: ReactNode
 }
 
-const ToolPage = ({ title = '', children }: Props): JSX.Element => {
+const ToolPage = ({ title = '', children }: Props): React.JSX.Element => {
   return <ToolPageLayout title={title}>{children}</ToolPageLayout>
 }
 

--- a/src/theme/ToolPage/ToolPageLayout.tsx
+++ b/src/theme/ToolPage/ToolPageLayout.tsx
@@ -8,7 +8,7 @@ interface Props {
   wide?: boolean
 }
 
-const ToolPageLayout = ({ children, title = '', wide = false }: Props): JSX.Element => {
+const ToolPageLayout = ({ children, title = '', wide = false }: Props): React.JSX.Element => {
   return (
     <Layout
       wrapperClassName={cx('w-full max-w-7xl mx-auto py-8 px-4', {

--- a/src/theme/concepts/BlogListPage/index.tsx
+++ b/src/theme/concepts/BlogListPage/index.tsx
@@ -5,7 +5,7 @@ import Link from '@docusaurus/Link'
 import ProcessedImage from '../components/ProcessedImage'
 import { useProcessedImage } from '../hooks/useProcessedImage'
 
-export default function ConceptsBlogListPage(props: Props): JSX.Element {
+export default function ConceptsBlogListPage(props: Props): React.JSX.Element {
   const { items, metadata } = props
   const { blogTitle, blogDescription } = metadata
 

--- a/src/theme/concepts/BlogPostPage/index.tsx
+++ b/src/theme/concepts/BlogPostPage/index.tsx
@@ -22,7 +22,7 @@ const ChevronRight = ({ className }: { className?: string }) => (
   </svg>
 )
 
-export default function ConceptsBlogPostPage(props: Props): JSX.Element {
+export default function ConceptsBlogPostPage(props: Props): React.JSX.Element {
   const { content: BlogPostContent } = props
   const { metadata, frontMatter } = BlogPostContent
   const { title, nextItem, prevItem, editUrl, tags, source } = metadata

--- a/src/theme/concepts/components/OptimizedThumbnail.tsx
+++ b/src/theme/concepts/components/OptimizedThumbnail.tsx
@@ -22,7 +22,7 @@ export default function OptimizedThumbnail({
   imageUrl,
   title,
   className = 'w-full h-full object-cover group-hover:scale-105 transition-transform duration-200',
-}: OptimizedThumbnailProps): JSX.Element {
+}: OptimizedThumbnailProps): React.JSX.Element {
   const optimizedUrl = optimizeImageUrl(imageUrl)
 
   return <img src={optimizedUrl} alt={title} className={className} loading="lazy" />

--- a/src/theme/concepts/components/ProcessedImage.spec.tsx
+++ b/src/theme/concepts/components/ProcessedImage.spec.tsx
@@ -123,7 +123,7 @@ describe('ProcessedImage', () => {
     render(<ProcessedImage processedData={null} size="medium" alt="Test image" />)
 
     const img = screen.getByAltText('Test image')
-    expect(img).toHaveAttribute('src', '')
+    expect(img).not.toHaveAttribute('src')
   })
 
   it('falls back to src when processed size not available', () => {

--- a/src/theme/concepts/components/ProcessedImage.tsx
+++ b/src/theme/concepts/components/ProcessedImage.tsx
@@ -16,7 +16,7 @@ export default function ProcessedImage({
   alt,
   className = '',
   enableModal = false,
-}: ProcessedImageProps): JSX.Element {
+}: ProcessedImageProps): React.JSX.Element {
   const [isModalOpen, setIsModalOpen] = useState(false)
 
   // Get the appropriate image URL based on size

--- a/yarn.lock
+++ b/yarn.lock
@@ -8990,13 +8990,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/prop-types@npm:*":
-  version: 15.7.11
-  resolution: "@types/prop-types@npm:15.7.11"
-  checksum: 10/7519ff11d06fbf6b275029fe03fff9ec377b4cb6e864cac34d87d7146c7f5a7560fd164bdc1d2dbe00b60c43713631251af1fd3d34d46c69cd354602bc0c7c54
-  languageName: node
-  linkType: hard
-
 "@types/qs@npm:*":
   version: 6.9.12
   resolution: "@types/qs@npm:6.9.12"
@@ -9011,12 +9004,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-dom@npm:^18.3.7":
-  version: 18.3.7
-  resolution: "@types/react-dom@npm:18.3.7"
+"@types/react-dom@npm:^19":
+  version: 19.2.3
+  resolution: "@types/react-dom@npm:19.2.3"
   peerDependencies:
-    "@types/react": ^18.0.0
-  checksum: 10/317569219366d487a3103ba1e5e47154e95a002915fdcf73a44162c48fe49c3a57fcf7f57fc6979e70d447112681e6b13c6c3c1df289db8b544df4aab2d318f3
+    "@types/react": ^19.2.0
+  checksum: 10/616c4a8aee250ea05fb1e7b98e7e00475dd3a6c1c30d7be18b4b93caba832f4203106b3a496a6b147e5acc2da14575eca47bce234c633bca1f8430ef8ffb234a
   languageName: node
   linkType: hard
 
@@ -9070,24 +9063,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:*":
-  version: 18.2.65
-  resolution: "@types/react@npm:18.2.65"
+"@types/react@npm:^19":
+  version: 19.2.14
+  resolution: "@types/react@npm:19.2.14"
   dependencies:
-    "@types/prop-types": "npm:*"
-    "@types/scheduler": "npm:*"
-    csstype: "npm:^3.0.2"
-  checksum: 10/8022689f6c68e76b5e7b3c95af794fb3d128d5b2ccac408adaa80b117724c48b04dd4a2750e5c2ca29cd70ac7719b4ed5c5b1c12cb739d6f1d52188c09fb3060
-  languageName: node
-  linkType: hard
-
-"@types/react@npm:^18.3.28":
-  version: 18.3.28
-  resolution: "@types/react@npm:18.3.28"
-  dependencies:
-    "@types/prop-types": "npm:*"
     csstype: "npm:^3.2.2"
-  checksum: 10/6db7bb7f19957ee9f530baa7d143527f8befedad1585b064eb80777be0d84621157de75aba4f499ff429b10c5ef0c7d13e89be6bca3296ef71c80472894ff0eb
+  checksum: 10/fbff239089ee64b6bd9b00543594db498278b06de527ef1b0f71bb0eb09cc4445a71b5dd3c0d3d0257255c4eed94406be40a74ad4a987ade8a8d5dd65c82bc5f
   languageName: node
   linkType: hard
 
@@ -9120,13 +9101,6 @@ __metadata:
   dependencies:
     "@types/node": "npm:*"
   checksum: 10/7ece5fbb5d9c8fc76ab0de2f99d705edf92f18e701d4f9d9b0647275e32eb65e656c1badf9dfaa12f4e1ff3e250561c8c9cfe79e8b5f33dd1417ac0f1804f6cc
-  languageName: node
-  linkType: hard
-
-"@types/scheduler@npm:*":
-  version: 0.16.8
-  resolution: "@types/scheduler@npm:0.16.8"
-  checksum: 10/6c091b096daa490093bf30dd7947cd28e5b2cd612ec93448432b33f724b162587fed9309a0acc104d97b69b1d49a0f3fc755a62282054d62975d53d7fd13472d
   languageName: node
   linkType: hard
 
@@ -12097,7 +12071,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"csstype@npm:^3.0.2, csstype@npm:^3.1.3":
+"csstype@npm:^3.1.3":
   version: 3.1.3
   resolution: "csstype@npm:3.1.3"
   checksum: 10/f593cce41ff5ade23f44e77521e3a1bcc2c64107041e1bf6c3c32adc5187d0d60983292fda326154d20b01079e24931aa5b08e4467cc488b60bb1e7f6d478ade
@@ -21246,15 +21220,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-dom@npm:^18.3.1":
-  version: 18.3.1
-  resolution: "react-dom@npm:18.3.1"
+"react-dom@npm:^19":
+  version: 19.2.5
+  resolution: "react-dom@npm:19.2.5"
   dependencies:
-    loose-envify: "npm:^1.1.0"
-    scheduler: "npm:^0.23.2"
+    scheduler: "npm:^0.27.0"
   peerDependencies:
-    react: ^18.3.1
-  checksum: 10/3f4b73a3aa083091173b29812b10394dd06f4ac06aff410b74702cfb3aa29d7b0ced208aab92d5272919b612e5cda21aeb1d54191848cf6e46e9e354f3541f81
+    react: ^19.2.5
+  checksum: 10/ba14b022c7191d27b723314b964a1a4d839832e6edd231294097e323973808f97ac647bcf182ab0104e20ae6532dbc36733aec3e8333a1446a7183099c96b255
   languageName: node
   linkType: hard
 
@@ -21514,12 +21487,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react@npm:^18.3.1":
-  version: 18.3.1
-  resolution: "react@npm:18.3.1"
-  dependencies:
-    loose-envify: "npm:^1.1.0"
-  checksum: 10/261137d3f3993eaa2368a83110466fc0e558bc2c7f7ae7ca52d94f03aac945f45146bd85e5f481044db1758a1dbb57879e2fcdd33924e2dde1bdc550ce73f7bf
+"react@npm:^19":
+  version: 19.2.5
+  resolution: "react@npm:19.2.5"
+  checksum: 10/1c3c7ffecb90b7f89a5c3ef635e6811f3a84600097f203b918150cb7e6b0a52915e858e5b4c82317a520dffccfa46ee4819ccf92c59c5b2d6c25cffe258dd20c
   languageName: node
   linkType: hard
 
@@ -22271,12 +22242,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"scheduler@npm:^0.23.2":
-  version: 0.23.2
-  resolution: "scheduler@npm:0.23.2"
-  dependencies:
-    loose-envify: "npm:^1.1.0"
-  checksum: 10/e8d68b89d18d5b028223edf090092846868a765a591944760942b77ea1f69b17235f7e956696efbb62c8130ab90af7e0949bfb8eba7896335507317236966bc9
+"scheduler@npm:^0.27.0":
+  version: 0.27.0
+  resolution: "scheduler@npm:0.27.0"
+  checksum: 10/eab3c3a8373195173e59c147224fc30dabe6dd453f248f5e610e8458512a5a2ee3a06465dc400ebfe6d35c9f5b7f3bb6b2e41c88c86fd177c25a73e7286a1e06
   languageName: node
   linkType: hard
 
@@ -23751,8 +23720,8 @@ __metadata:
     "@types/jest": "npm:^30.0.0"
     "@types/js-cookie": "npm:^3.0.6"
     "@types/node": "npm:^25"
-    "@types/react": "npm:^18.3.28"
-    "@types/react-dom": "npm:^18.3.7"
+    "@types/react": "npm:^19"
+    "@types/react-dom": "npm:^19"
     "@typescript/native-preview": "npm:7.0.0-dev.20260425.1"
     "@vitest/coverage-v8": "npm:^4"
     canvas: "npm:^3.2.3"
@@ -23774,8 +23743,8 @@ __metadata:
     prettier: "npm:^3.8.3"
     prism-react-renderer: "npm:^2.4.1"
     qrcode.react: "npm:^4.2.0"
-    react: "npm:^18.3.1"
-    react-dom: "npm:^18.3.1"
+    react: "npm:^19"
+    react-dom: "npm:^19"
     react-hot-toast: "npm:^2.6.0"
     react-icons: "npm:^5.6.0"
     react-simple-code-editor: "npm:^0.14.1"


### PR DESCRIPTION
## What

- react / react-dom 18 \u2192 19
- @types/react / @types/react-dom 18 \u2192 19
- yarn `resolutions` pin both `@types/react` and `@types/react-dom` to `^19` so the nested `@types/react@18` inside `@docusaurus/types` doesn't surface ReactNode incompatibilities (React 19's `ReactNode` now includes `bigint`).

Docusaurus 3.10's peerDependencies range is `^18.0.0 || ^19.0.0`, so no upstream changes are required.

## Code changes required by React 19

### Global `JSX` namespace removal
The global `JSX` namespace is gone in React 19's types. 25 theme/component files using `JSX.Element` switched to `React.JSX.Element`.

### `<img src="">` no longer emits the attribute
React 19 deliberately omits an empty `src` attribute on `<img>` to avoid the browser refetching the page. `ProcessedImage.spec.tsx` updated:

```diff
- expect(img).toHaveAttribute('src', '')
+ expect(img).not.toHaveAttribute('src')
```

## Verification

- `yarn lint` clean (oxlint)
- `yarn typecheck` clean (tsgo)
- `yarn test --run` \u2014 163/163 pass
- `yarn build` green; post-build security tests 3/3 pass
- HTML smoke check: `/`, `/learning`, `/blog` all hydrate correctly

## Caveats

- React 19's `forwardRef` and a few APIs are deprecated (will warn at runtime). No production warnings observed in the build, but a follow-up to clean up any `forwardRef` usage might be worth doing.