### PR TITLE
fix(a11y): address Lighthouse-flagged accessibility issues

### DIFF
--- a/src/components/CookieConsent/CookieConsent.tsx
+++ b/src/components/CookieConsent/CookieConsent.tsx
@@ -64,7 +64,7 @@ const CookieConsent: React.FC = () => {
           <button
             type="button"
             onClick={handleAccept}
-            className="cursor-pointer rounded-lg border-0 bg-pink px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-pink-dark"
+            className="cursor-pointer rounded-lg border-0 bg-pink-darkest px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-pink-dark"
           >
             Accept
           </button>

--- a/src/components/Home/index.tsx
+++ b/src/components/Home/index.tsx
@@ -29,6 +29,7 @@ const Index = (): React.ReactElement => {
             <Image
               className="[&:not(dialog_&)_img]:rounded-lg"
               img={require('@site/src/assets/webber.jpg')}
+              alt="Portrait of Webber Takken"
             />
           </div>
 
@@ -85,21 +86,26 @@ const Index = (): React.ReactElement => {
           <Card title="Projects">
             <Card.Item>
               🎮{' '}
-              <a href="https://minis.gg" target="_blank" rel="noreferrer">
+              <a href="https://minis.gg" target="_blank" rel="noreferrer" className="underline">
                 Minis.gg
               </a>{' '}
               (free gaming platform)
             </Card.Item>
             <Card.Item>
               📺{' '}
-              <a href="https://github.com/webbertakken/streamer" target="_blank" rel="noreferrer">
+              <a
+                href="https://github.com/webbertakken/streamer"
+                target="_blank"
+                rel="noreferrer"
+                className="underline"
+              >
                 Streamer
               </a>{' '}
               (free streamer software)
             </Card.Item>
             <Card.Item>
               🌍{' '}
-              <a href="https://game.ci" target="_blank" rel="noreferrer">
+              <a href="https://game.ci" target="_blank" rel="noreferrer" className="underline">
                 GameCI
               </a>{' '}
               (open source community)


### PR DESCRIPTION
## What

Lighthouse audit on `https://www.takken.io/` (mobile, dark mode active) flagged three concrete a11y issues. This PR fixes them.

| Issue | Element | Before | After |
|---|---|---|---|
| Missing alt | profile portrait on home page | no `alt` attr | `alt="Portrait of Webber Takken"` |
| Color-alone link distinction (WCAG 1.4.1) | external links in Projects card (Minis.gg / Streamer / GameCI) | colour only | added `underline` class |
| Insufficient contrast (3.42, needs 4.5) | cookie-consent Accept button | `bg-pink` + `text-white` | `bg-pink-darkest` + `text-white` (~4.7 dark / ~8.7 light) |

## Not changed

The active navbar item (`.navbar__title.navbar__link--active`) fails contrast marginally (4.48 vs 4.5) in dark mode \u2014 it's Docusaurus' `--ifm-color-primary` which maps to our brand pink. Fixing means changing the brand colour, deferred to a separate decision.

## Verification

- `yarn lint` clean
- `yarn typecheck` clean
- `yarn test --run` \u2014 163/163 pass
- `yarn build` green; post-build security 3/3 pass