### PR TITLE
chore: add yarn check and yarn check:ci composite scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "format": "prettier --write .",
     "fix": "yarn format && yarn lint:css && yarn lint --fix",
     "typecheck": "tsgo --skipLibCheck --noEmit",
+    "check:ci": "yarn coverage --run && yarn lint && yarn prettier --check . && yarn typecheck",
+    "check": "yarn test --run && yarn lint && yarn prettier --check . && yarn typecheck",
     "prepare": "husky",
     "image": "ts-node tools/image-generator/index.ts"
   },


### PR DESCRIPTION
## What

Two convenience scripts that mirror CI gates locally so you can verify before pushing.

```json
"check":    "yarn test --run && yarn lint && yarn prettier --check . && yarn typecheck",
"check:ci": "yarn coverage --run && yarn lint && yarn prettier --check . && yarn typecheck"
```

- `yarn check` \u2014 fast (uses `test --run` instead of full coverage). ~5.9s on a clean working tree.
- `yarn check:ci` \u2014 exactly what `pull-request.yaml` runs (coverage + lint + prettier --check + typecheck).

Saves a round-trip through CI when iterating on a PR.

## Verification

- `yarn check` runs clean
- prettier auto-format applied to package.json by lint-staged