### PR TITLE
chore: move vitest related to pre-push, faster pre-commit

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,4 @@
+# If tty is available, apply fix from https://github.com/typicode/husky/issues/968#issuecomment-1176848345
+if sh -c ": >/dev/tty" >/dev/null 2>/dev/null; then exec >/dev/tty 2>&1; fi
+
+yarn vitest related --run --changed origin/main

--- a/package.json
+++ b/package.json
@@ -33,10 +33,7 @@
       "git update-index --chmod=+x"
     ],
     "*.@(ts|tsx|mts)": "bash -c 'tsgo --skipLibCheck --noEmit'",
-    "*.@(ts|tsx|mts|js|jsx|mjs|cjs)": [
-      "oxlint --max-warnings 0",
-      "vitest related --run"
-    ],
+    "*.@(ts|tsx|mts|js|jsx|mjs|cjs)": "oxlint --max-warnings 0",
     "*.@(ts|tsx|mts|js|jsx|mjs|cjs|json|jsonc|json5|md|mdx|yaml|yml)": "prettier --write",
     "*.@(css|scss|sass)": "stylelint --fix",
     "{blog,notes}/**/*.@(md|mdx)": "node tools/validate-frontmatter.mjs"


### PR DESCRIPTION
## What

Move `vitest related --run` out of the lint-staged pre-commit hook and into a dedicated pre-push hook. Pre-commit now only runs the strictly file-scoped checks (oxlint, tsgo, prettier, stylelint, frontmatter validation, shellcheck) \u2014 all sub-second. Tests run once at push time against the diff vs `origin/main`.

## Trade-off

A broken test only blocks at push, not at commit. In return:

- Day-to-day commits become noticeably faster.
- Tests run on the full set of files actually changed by the push, rather than per-commit fragments.
- CI still catches anything that escapes the local pre-push.

## Verification

- `yarn vitest related --run --changed origin/main` runs cleanly.
- `yarn lint` / `yarn typecheck` / `yarn test --run` / `yarn build` all green.
- Pre-commit hook and pre-push hook both trigger correctly (verified during the commit/push of this PR).