### PR TITLE
feat: add og:image dimensions for reliable social card rendering

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -213,6 +213,11 @@ export default {
         name: 'darkreader-lock',
         content: 'this site supported dark mode and uses QR codes with white backgrounds',
       },
+      { property: 'og:image:type', content: 'image/png' },
+      { property: 'og:image:width', content: '1200' },
+      { property: 'og:image:height', content: '630' },
+      { property: 'og:image:alt', content: 'Takken.io — notes, thoughts, projects' },
+      { name: 'twitter:image:alt', content: 'Takken.io — notes, thoughts, projects' },
     ],
     navbar: {
       title: 'Takken.io',


### PR DESCRIPTION
## What

Add the missing `og:image:width`, `og:image:height`, `og:image:type`, and `og:image:alt` meta tags (plus `twitter:image:alt`) so platforms render the full social card reliably.

## Why

Production was emitting:

```
<meta property="og:image" content="https://takken.io/images/og.png">
<meta name="twitter:image" content="https://takken.io/images/og.png">
<meta name="twitter:card" content="summary_large_image">
```

That works in some clients, but **Discord, Slack, LinkedIn, and Telegram** sometimes fall back to a small-thumbnail layout when the image dimensions aren't declared up-front (so they don't have to fetch+parse the image to know its aspect ratio).

## What's added

```
<meta property="og:image:type"   content="image/png">
<meta property="og:image:width"  content="1200">
<meta property="og:image:height" content="630">
<meta property="og:image:alt"    content="Takken.io \u2014 notes, thoughts, projects">
<meta name="twitter:image:alt"   content="Takken.io \u2014 notes, thoughts, projects">
```

## Notes

- **Cache-bust to test**: existing Discord embeds will keep showing whatever was cached at the first scrape (24-48h). Re-post the link with a unique query string (e.g. `?v=2`) to force Discord to re-scrape against the now-complete metadata.
- Verified in built static HTML for `/`.

## Verification

- `yarn check` clean (lint, prettier --check, typecheck, tests 163/163)
- `yarn build` green; post-build security 3/3 pass