### PR TITLE
fix(ux): eliminate navbar CLS when navigating to/from /learning

### DIFF
--- a/src/theme/Navbar/Content/index.tsx
+++ b/src/theme/Navbar/Content/index.tsx
@@ -121,16 +121,14 @@ const NavbarContent = (): React.ReactElement => {
   const { pathname } = useLocation()
   const isLearningPage = pathname === '/learning' || pathname.startsWith('/learning/')
 
-  if (!isLearningPage) {
-    return <OriginalNavbarContent />
-  }
-
+  // Reserve the profile-menu slot on every page so the navbar layout is
+  // identical across routes. Only mount the actual menu on /learning.
   return (
     <div className="flex w-full items-center">
       <div className="flex-1">
         <OriginalNavbarContent />
       </div>
-      <ProfileMenu />
+      {isLearningPage ? <ProfileMenu /> : <div aria-hidden="true" className="ml-2 h-8 w-8" />}
     </div>
   )
 }


### PR DESCRIPTION
## Problem

The navbar layout shifts when navigating to or from `/learning`. On non-learning pages the swizzled `NavbarContent` returned `<OriginalNavbarContent />` directly (full width). On `/learning` it wrapped the original navbar in a flex container with the `<ProfileMenu />` (~40px) on the right. Switching routes caused the navbar children to jump horizontally.

## Fix

Always render the same wrapper structure and reserve the same 40px slot. Mount the real profile menu only on `/learning`; render an `aria-hidden` placeholder of the exact same dimensions (`ml-2 h-8 w-8`) on every other route.

```tsx
return (
  <div className="flex w-full items-center">
    <div className="flex-1">
      <OriginalNavbarContent />
    </div>
    {isLearningPage ? <ProfileMenu /> : <div aria-hidden="true" className="ml-2 h-8 w-8" />}
  </div>
)
```

The visible behaviour is unchanged \u2014 the profile menu is still only present on `/learning`. The navbar layout is now identical across routes.

## Verification (built static HTML)

| Page | Wrapper | Right-hand slot |
|---|---|---|
| `/` | `<div class="flex w-full items-center">` | `aria-hidden="true" class="ml-2 h-8 w-8"` |
| `/blog/<post>` | same | same placeholder |
| `/learning` | same | `aria-label="User menu"` (real menu) |

- `yarn check` clean
- `yarn build` green; post-build security 3/3 pass