### PR TITLE
feat: redesign /tools as a card grid

### DIFF
--- a/src/pages/tools/index.tsx
+++ b/src/pages/tools/index.tsx
@@ -1,20 +1,77 @@
+import type { ComponentType } from 'react'
+import {
+  FaArrowRight,
+  FaCodePullRequest,
+  FaListUl,
+  FaMagnifyingGlass,
+  FaPersonSwimming,
+  FaPlug,
+} from 'react-icons/fa6'
 import ToolPageLayout from '@theme/ToolPage/ToolPageLayout'
 
-const tools = [
-  { name: 'Pull requests to release text', slug: 'pull-requests-to-release-text' },
-  { name: 'Garmin to SSI dive log helper', slug: 'garmin-to-ssi-dive-log-helper' },
-  { name: 'Tasmota helper', slug: 'tasmota-helper' },
-  { name: 'Text analyser', slug: 'text-analyser' },
-  { name: 'Comma separator', slug: 'comma-separator' },
+interface Tool {
+  name: string
+  slug: string
+  description: string
+  Icon: ComponentType<{ className?: string; 'aria-hidden'?: boolean }>
+}
+
+const tools: Tool[] = [
+  {
+    name: 'Pull requests to release text',
+    slug: 'pull-requests-to-release-text',
+    description: 'Turn a list of merged pull requests into clean, categorised release notes.',
+    Icon: FaCodePullRequest,
+  },
+  {
+    name: 'Garmin to SSI dive log helper',
+    slug: 'garmin-to-ssi-dive-log-helper',
+    description: 'Convert a Garmin .FIT dive file into a QR code your SSI DiveLog app can scan.',
+    Icon: FaPersonSwimming,
+  },
+  {
+    name: 'Tasmota helper',
+    slug: 'tasmota-helper',
+    description: 'Calibrate Tasmota smart plugs against a reference power meter or multimeter.',
+    Icon: FaPlug,
+  },
+  {
+    name: 'Text analyser',
+    slug: 'text-analyser',
+    description: 'Paste any text and inspect its words, characters, and frequency stats.',
+    Icon: FaMagnifyingGlass,
+  },
+  {
+    name: 'Comma separator',
+    slug: 'comma-separator',
+    description: 'Split or join a collection of items with custom delimiters and quote characters.',
+    Icon: FaListUl,
+  },
 ]
 
 const Tools = (): React.JSX.Element => {
   return (
     <ToolPageLayout title="Tools">
-      <ul>
-        {tools.map(({ name, slug }) => (
-          <li key={slug}>
-            <a href={`/tools/${slug}`}>{name}</a>
+      <p className="mb-8 text-gray-500 dark:text-gray-400">
+        Small in-browser utilities I built to scratch my own itches.
+      </p>
+      <ul className="m-0 grid list-none grid-cols-1 gap-4 p-0 md:grid-cols-2 lg:grid-cols-3">
+        {tools.map(({ name, slug, description, Icon }) => (
+          <li key={slug} className="m-0">
+            <a
+              href={`/tools/${slug}`}
+              className="group flex h-full flex-col rounded-lg border-2 border-solid border-gray-200 p-5 no-underline transition-transform duration-200 hover:scale-[1.02] hover:border-pink hover:no-underline dark:border-gray-700 dark:hover:border-pink-light"
+            >
+              <div className="mb-3 flex items-center justify-between">
+                <Icon aria-hidden className="h-8 w-8 text-pink dark:text-pink-light" />
+                <FaArrowRight
+                  aria-hidden
+                  className="h-4 w-4 -translate-x-1 text-gray-300 opacity-0 transition-all group-hover:translate-x-0 group-hover:opacity-100 dark:text-gray-500"
+                />
+              </div>
+              <h2 className="mb-2 text-lg font-semibold text-gray-900 dark:text-white">{name}</h2>
+              <p className="m-0 text-sm text-gray-500 dark:text-gray-400">{description}</p>
+            </a>
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## What

Replace the bulleted list of tools with a responsive card grid.

## Layout

- **Mobile (< 768px)**: 1 column
- **Tablet (`md:`)**: 2 columns
- **Desktop (`lg:`)**: 3 columns

Each card carries:

- A Font Awesome 6 icon (brand pink in light mode, lighter pink in dark mode to match the navbar-contrast fix).
- Bold tool name heading.
- One-line description of what the tool does.
- Arrow indicator that slides in on hover.

## Hover behaviour

- 2% uniform scale on the whole card (subtle).
- Border swaps to brand pink.
- No underline anywhere; whole card is the link.

## Tools and descriptions

| Tool | Icon | Description |
|---|---|---|
| Pull requests to release text | code-pull-request | Turn a list of merged pull requests into clean, categorised release notes. |
| Garmin to SSI dive log helper | person-swimming | Convert a Garmin .FIT dive file into a QR code your SSI DiveLog app can scan. |
| Tasmota helper | plug | Calibrate Tasmota smart plugs against a reference power meter or multimeter. |
| Text analyser | magnifying-glass | Paste any text and inspect its words, characters, and frequency stats. |
| Comma separator | list-ul | Split or join a collection of items with custom delimiters and quote characters. |

## Verification

- `yarn check` clean
- `yarn build` green; post-build security 3/3 pass
- All 5 cards link to the right tool; each tool page returns 200
- Visual smoke test at 1280\u00d7900 desktop and 420\u00d7900 mobile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Redesigned Tools page with enhanced card-based layout.
  * Each tool card now displays an icon, name, and detailed description.
  * Implemented responsive grid design for improved mobile and desktop viewing.
  * Added interactive hover effects and visual indicators to enhance user engagement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->