### PR TITLE
fix: exclude static/ from prettier checks

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,7 @@ dist/
 coverage/
 node_modules/
 .yarn/
+static/
 
 # CSS files are handled by stylelint
 *.css


### PR DESCRIPTION
Static assets (standalone HTML files, images, etc.) should not be formatted by Prettier. Fixes CI failure on main.