### PR TITLE
ci(main): cache node_modules + yarn cache + install-state

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,6 +11,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Read Node version from mise.toml
+        id: node
+        run:
+          echo "version=$(grep -E '^node\s*=' mise.toml | sed -E 's/.*"([^"]+)".*/\1/')" >>
+          "$GITHUB_OUTPUT"
+
       - name: Install package manager (from package.json)
         run: |
           corepack enable
@@ -19,11 +25,32 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version-file: package.json
-          cache: 'yarn'
+          node-version: ${{ steps.node.outputs.version }}
+
+      - name: Resolve yarn cache folder
+        id: yarn-config
+        run: echo "cacheFolder=$(yarn config get cacheFolder)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore yarn install cache (node_modules + cacheFolder + install-state)
+        id: yarn-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+            ${{ steps.yarn-config.outputs.cacheFolder }}
+            .yarn/install-state.gz
+          key:
+            yarn-${{ runner.os }}-node${{ steps.node.outputs.version }}-${{ hashFiles('yarn.lock')
+            }}
+          restore-keys: |
+            yarn-${{ runner.os }}-node${{ steps.node.outputs.version }}-
 
       - name: Install deps
-        run: yarn install --frozen-lockfile --immutable
+        env:
+          YARN_ENABLE_HARDENED_MODE: 'false'
+        run: |
+          case "$(yarn --version)" in 1.*) echo 'expected up-to-date yarn version'; exit 1 ;; esac
+          yarn install --immutable
 
       - name: Tests
         run: yarn coverage
@@ -55,6 +82,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Read Node version from mise.toml
+        id: node
+        run:
+          echo "version=$(grep -E '^node\s*=' mise.toml | sed -E 's/.*"([^"]+)".*/\1/')" >>
+          "$GITHUB_OUTPUT"
+
       - name: Install package manager (from package.json)
         run: |
           corepack enable
@@ -63,11 +96,30 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version-file: package.json
-          cache: 'yarn'
+          node-version: ${{ steps.node.outputs.version }}
+
+      - name: Resolve yarn cache folder (functions)
+        id: yarn-config
+        run: echo "cacheFolder=$(yarn --cwd functions config get cacheFolder)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore yarn install cache (functions/node_modules + cacheFolder + install-state)
+        id: yarn-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            functions/node_modules
+            ${{ steps.yarn-config.outputs.cacheFolder }}
+            functions/.yarn/install-state.gz
+          key:
+            yarn-functions-${{ runner.os }}-node${{ steps.node.outputs.version }}-${{
+            hashFiles('functions/yarn.lock') }}
+          restore-keys: |
+            yarn-functions-${{ runner.os }}-node${{ steps.node.outputs.version }}-
 
       - name: Install function dependencies
-        run: yarn --cwd functions install --frozen-lockfile --immutable
+        env:
+          YARN_ENABLE_HARDENED_MODE: 'false'
+        run: yarn --cwd functions install --immutable
 
       - name: Build functions
         run: yarn --cwd functions build

--- a/functions/yarn.lock
+++ b/functions/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 8
+  version: 9
   cacheKey: 10
 
 "@fastify/busboy@npm:^3.0.0":


### PR DESCRIPTION
main.yaml was still on the slow setup-node + cache: 'yarn' pattern. The PR #275 merge only updated pull-request.yaml. This brings main.yaml in line — same Read-Node-from-mise.toml step + actions/cache@v4 covering node_modules + .yarn/cache + install-state.gz, for both `checks` and `deploy-firebase` jobs.

Without this, main.yaml would also have failed on the next push since `node-version-file: package.json` no longer resolves (volta block was removed).