### PR TITLE
fix(firebase): enable corepack in predeploy build hook

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -5,6 +5,6 @@
   "functions": {
     "source": "functions",
     "runtime": "nodejs22",
-    "predeploy": "yarn --cwd functions build"
+    "predeploy": "corepack enable && yarn --cwd functions build"
   }
 }


### PR DESCRIPTION
Predeploy step in firebase.json runs inside the w9jds/firebase-action Docker container, which has yarn 1.x and no corepack shim active. After bumping packageManager to yarn@4.14.1 (PR #275), this errored:

```
error This project's package.json defines "packageManager": "yarn@4.14.1".
However the current global version of Yarn is 1.22.22.
```

Prefixing the predeploy with `corepack enable` activates the corepack shim before yarn runs, so the project-pinned yarn version takes over. Works in CI (the firebase-action image is Node-based and corepack ships with Node 16.9+) and in local dev (no-op if corepack is already enabled).

This unblocks deploy-firebase on main, which has been failing since the yarn 4.14.1 bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Firebase Functions build configuration to enhance deployment reliability and ensure consistent dependency management during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->