### PR TITLE
fix(functions): pin nodeLinker: node-modules

### DIFF
--- a/functions/.yarnrc.yml
+++ b/functions/.yarnrc.yml
@@ -4,3 +4,9 @@
 # `yarn install --immutable` errors with a "lockfile would have been
 # modified" diff.
 compressionLevel: 0
+
+# Yarn 4 default is PnP. Firebase Functions Cloud Build detects PnP
+# and demands @google-cloud/functions-framework be in dependencies.
+# Pin node-modules so installs work the same as the root project and
+# Cloud Build doesn't trip the PnP check.
+nodeLinker: node-modules


### PR DESCRIPTION
Cloud Build was installing functions/ in PnP mode (yarn 4 default when `nodeLinker` isn't set) and tripping its PnP-detected check, demanding `@google-cloud/functions-framework` be in dependencies and failing the function build phase.

Pin `nodeLinker: node-modules` in `functions/.yarnrc.yml` so Cloud Build installs the same way as the root project (which has `nodeLinker: node-modules` set) and our local installs.

Lockfile unchanged. After merge, the deploy-firebase job on main should finally complete end-to-end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build system configuration to optimise reproducibility and reliability in Cloud Build deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->