### PR TITLE
chore(functions): bump firebase-functions + firebase-admin to latest

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -10,8 +10,8 @@
     "format": "prettier --write src/"
   },
   "dependencies": {
-    "firebase-admin": "^13.0.0",
-    "firebase-functions": "^7.2.2",
+    "firebase-admin": "^13.8.0",
+    "firebase-functions": "^7.2.5",
     "resend": "^4.1.0"
   },
   "devDependencies": {

--- a/functions/yarn.lock
+++ b/functions/yarn.lock
@@ -1073,9 +1073,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"firebase-admin@npm:^13.0.0":
-  version: 13.7.0
-  resolution: "firebase-admin@npm:13.7.0"
+"firebase-admin@npm:^13.8.0":
+  version: 13.8.0
+  resolution: "firebase-admin@npm:13.8.0"
   dependencies:
     "@fastify/busboy": "npm:^3.0.0"
     "@firebase/database-compat": "npm:^2.0.0"
@@ -1087,20 +1087,20 @@ __metadata:
     google-auth-library: "npm:^10.6.1"
     jsonwebtoken: "npm:^9.0.0"
     jwks-rsa: "npm:^3.1.0"
-    node-forge: "npm:^1.3.1"
+    node-forge: "npm:^1.4.0"
     uuid: "npm:^11.0.2"
   dependenciesMeta:
     "@google-cloud/firestore":
       optional: true
     "@google-cloud/storage":
       optional: true
-  checksum: 10c0/1df48859bdc7b5c90a9bf48d321d4def6d704cec9087bf6afded5cc6524d47d93c37d636ac388b590a68228110360853d34ae710d4ec854f778a27cf60d7640f
+  checksum: 10c0/22e66bc1122d3c6ca4fb21f52db12c6b9cecaa275fe27aa1aa7ad1dd227ebdc91f0bb65acae88c9b813e9d9192bfe8e3bbe5666ea6e9b030fdf4ac9f2d02f902
   languageName: node
   linkType: hard
 
-"firebase-functions@npm:^7.2.2":
-  version: 7.2.2
-  resolution: "firebase-functions@npm:7.2.2"
+"firebase-functions@npm:^7.2.5":
+  version: 7.2.5
+  resolution: "firebase-functions@npm:7.2.5"
   dependencies:
     "@types/cors": "npm:^2.8.5"
     "@types/express": "npm:^4.17.21"
@@ -1121,7 +1121,7 @@ __metadata:
       optional: true
   bin:
     firebase-functions: lib/bin/firebase-functions.js
-  checksum: 10c0/19175bb71a99e04a668a64f44927e834d34983b3f6ab91e53e95f6605f1c820dd4147d94d1e611c90e33bdba2ae7df1a47f990258df95023cf20449e39de4f4d
+  checksum: 10c0/124f81ed4f3287ed0728b17d10774469c29ba52e87a8e04e534670acdccc0f7dbea9ffb16c560ac3a0a7215c9bf3a3de7e1158de47859e8bf1fc36117148374d
   languageName: node
   linkType: hard
 
@@ -1777,7 +1777,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-forge@npm:^1.3.1":
+"node-forge@npm:^1.4.0":
   version: 1.4.0
   resolution: "node-forge@npm:1.4.0"
   checksum: 10c0/67330a5f1f95257a4c8a93b7d555abe87b5f15e350123aa396c97a21a8ca94f9c6549008eb2c73668a91e0d7e3a905785acbd8f8bd0751c29401292011f8f8e1
@@ -2190,8 +2190,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "takken-io-functions@workspace:."
   dependencies:
-    firebase-admin: "npm:^13.0.0"
-    firebase-functions: "npm:^7.2.2"
+    firebase-admin: "npm:^13.8.0"
+    firebase-functions: "npm:^7.2.5"
     prettier: "npm:^3.4.0"
     resend: "npm:^4.1.0"
     typescript: "npm:^5.7.0"


### PR DESCRIPTION
Clears the deploy-time warning:
```
package.json indicates an outdated version of firebase-functions.
Please upgrade using npm install --save firebase-functions@latest
```

The carets in package.json (`^7.2.2`, `^13.0.0`) allowed newer minors but yarn.lock had pinned the older resolutions. `yarn up` forces the lockfile to current latest within range.

- firebase-functions: 7.2.2 -> 7.2.5
- firebase-admin: 13.7.0 -> 13.8.0

Both within the same major; no API breakage expected.